### PR TITLE
MAINT: Adapt to the R111 dialog mode rework

### DIFF
--- a/src/modules/deviousPadlock.ts
+++ b/src/modules/deviousPadlock.ts
@@ -699,14 +699,27 @@ export function loadDeviousPadlock(): void {
 		onAppearanceChange(target1, target2);
 	});
 
-	hookFunction("DrawImageResize", 20, (args, next) => {
-		var path = args[0];
-		if (typeof path === "object") return next(args);
-		if (!!path && path === `Assets/Female3DCG/ItemMisc/Preview/${deviousPadlock.Name}.png`) {
-			args[0] = deviousPadlockImage;
-		} 
-		return next(args);
-	});
+	if (GameVersion === "R110") {
+		hookFunction("DrawImageResize", 20, (args, next) => {
+			var path = args[0];
+			if (typeof path === "object") return next(args);
+			if (!!path && path === `Assets/Female3DCG/ItemMisc/Preview/${deviousPadlock.Name}.png`) {
+				args[0] = deviousPadlockImage;
+			}
+			return next(args);
+		});
+	} else { // R111
+		hookFunction("ElementButton.CreateForAsset", 0, (args, next) => {
+			args[4] ??= {};
+			const asset: Asset = "Asset" in args[1] ? args[1].Asset : args[1];
+			switch (asset.Name) {
+				case deviousPadlock.Name:
+					args[4].image = deviousPadlockImage;
+					break;
+			}
+			return next(args);
+		});
+	}
 
 	hookFunction("DialogInventoryAdd", 20, (args, next) => {
 		const [C, item, isWorn, sortOrder] = args;


### PR DESCRIPTION
Xref [BondageProjects/Bondage-College#5278](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5278)

Above-mentioned PR overhauls the UI of a number of dialog menu modes (including the `item` mode) for R111, switching from a canvas- to DOM-based UI. Consequently, custom items will now have to hook into `ElementButton.CreateForAsset()` in order to set their custom button images, a change which is thus introduced herein.

Includes changes both suitable for the beta-period and full R111 release.
