### PR TITLE
update: restore ignored properties on remove

### DIFF
--- a/src/modules/deviousPadlock.ts
+++ b/src/modules/deviousPadlock.ts
@@ -327,7 +327,7 @@ function checkDeviousPadlocks(target: Character): void {
 					let newItem: Item = InventoryWear(Player, savedItem.name, groupName, savedItem.color, difficulty, Player.MemberNumber, savedItem.craft);
 					newItem.Property = {
 						...getValidProperties(savedItem.property),
-						...getIgnoredProperties(currentItem?.Asset?.Name === savedItem.name ? currentItem.Property : newItem.Property)
+						...getIgnoredProperties(currentItem?.Asset?.Name === savedItem.name ? currentItem.Property : savedItem.property)
 					};
 					if (newItem.Property.Name !== deviousPadlock.Name) newItem.Property.Name = deviousPadlock.Name;
 					if (newItem.Property.LockedBy !== "ExclusivePadlock") newItem.Property.LockedBy = "ExclusivePadlock";
@@ -338,6 +338,9 @@ function checkDeviousPadlocks(target: Character): void {
 					pushChatRoom = true;
 					syncStorage();
 				}
+			} else if (JSON.stringify(getIgnoredProperties(currentItem?.Property)) !== JSON.stringify(getIgnoredProperties(savedItem.property))) {
+				modStorage.deviousPadlock.itemGroups[groupName].item = getSavedItemData(currentItem);
+				syncStorage();
 			}
 		});
 


### PR DESCRIPTION
This PR is *somewhat* of a suggestion and implementation combined. I say this because I'm unsure whether the original behaviour was intentionally chosen (making this a suggestion for an update) or overlooked (making this a bug fix).

## Summary
(edited in because I realize I may've gone on a bit of a ramble)

DOGS keeps a list of ignored properties that're mostly ignored (not enforced, handled lazily). One effect of this is that when a DOGS-locked item is removed, these ignored properties are not restored, which can be viewed as undesired or erroneous behaviour (see [Background](#background) for more detail). This implementation adjusts that behaviour -- ignored properties continue to be unenforced, however are stored and restored the same as "valid" (normal) properties. Consideration may need to be made as to the impacts of this re: packet throughput (see [Implementation Details](#implementation-details) for more detail).

---

## Background
Currently, DOGS maintains a list of "ignored properties" that're both not enforced and handled lazily (i.e. not stored on update unless accompanied by a non-lazy change) by DOGS. At the time of writing, this list is:
```js
const ignoredProperties = [
	"OrgasmCount", "RuinedOrgasmCount", "TimeSinceLastOrgasm",
	"TimeWorn", "TriggerCount"
];
```
The existence of ignored properties makes sense, as these properties are mostly for statistical purposes, would constantly be updated, and result in quite a number of false-positives (DOGS triggering everytime you have an orgasm would be quite something!).

However, the current implementation of ignored properties also means that if a DOGS-locked item is removed, swapped, or similar when it's not supposed to be (i.e. the person doesn't have access), these properties are completely reset when the item is readded by DOGS.

This, in my opinion, is undesirable, as it results in the aforementioned loss of data, which doesn't *really* match up with what you'd expect of a "lock". To elaborate on the latter point, most locks prevent removal or modification to begin with. This, of course, isn't possible for DOGS (due to non-mod users, console, etc.), so it attempts to replicate this by restoring the item when it *is* removed or modified. However, as these ignored properties are lost during restoration, we now have a case where an unauthorized action has managed to enact a change on the supposedly locked item (potentially to the wearer's detriment if they care about these statistics).

With this philosophy in mind, this PR implementation enables the restoration of these ignored properties.

## Implementation Details
The primary concern in implementing this change is whether it would cause an excess of packets to be sent (to the BC server and to other clients). This is especially the case as some of these properties (e.g. `OrgasmCount`, `RuinedOrgasmCount`, `TriggerCount`) have the potential to be modified rapidly (e.g. spamming standup when a device is set to punish standing, rapidly increasing `TriggerCount`).

In considering this, I've drawn the conclusion that it should *theoretically* be ok, as the cases where these properties are rapidly modified are rare, and in such cases, a number of packets are already sent (inventory item update + pose update + chat message), making DOGS' additional packets theoretically negligible in comparison.

Additionally, BC does also appear to do some delayed updating of its own, as some of these properties do not trigger their own item updates (hence not triggering DOGS either with their updates), instead necessitating an unrelated update to push their changes. The aforementioned `TriggerCount` example is one such case.

That said, I'm not confident in this conclusion either, and have debated for quite some time as to whether implementing a message queuing and/or cooldown system for ignored properties' updates (as they can generally be considered to be low priority -- an ignored property being slightly out of date is not usually a big deal; being accurate is a nice-to-have). As you may be able to see in this PR, I opted not to, but if you have thoughts on this, I would like to hear them (and would certainly not be opposed to changing my approach).