### PR TITLE
feat: allow non-exclusive base padlocks

### DIFF
--- a/src/modules/deviousPadlock.ts
+++ b/src/modules/deviousPadlock.ts
@@ -20,6 +20,12 @@ export const deviousPadlock: AssetDefinition.Item = {
 	RemoveTime: 1000
 };
 
+export enum BasePadlock {
+	EXCLUSIVE = "ExclusivePadlock",
+	LOVERS = "LoversPadlock",
+	OWNER = "OwnerPadlock",
+};
+
 export enum PutPadlockMinimumRole {
 	PUBLIC = 3,
 	FRIEND = 0,
@@ -50,6 +56,7 @@ export interface DeviousPadlockConfigurations {
 		type: "PIN-Code" | "password"
 		value: string
 	}
+	baseLock: BasePadlock
 	unlockTime: string
 	keyHolders: {
 		minimumRole: KeyHolderMinimumRole
@@ -103,10 +110,18 @@ export function registerDeviousPadlockInModStorage(group: AssetGroupItemName, ow
 		modStorage.deviousPadlock.itemGroups = {};
 	}
 	const currentItem = InventoryGet(Player, group);
-	modStorage.deviousPadlock.itemGroups[group] = {
+	const lockDef: ModStorage["deviousPadlock"]["itemGroups"][AssetGroupItemName] = {
 		item: getSavedItemData(currentItem),
-		owner: ownerId
+		owner: ownerId,
 	};
+
+	const lockedBy = currentItem?.Property?.LockedBy;
+	if (lockedBy && lockedBy !== BasePadlock.EXCLUSIVE && Object.values(BasePadlock).includes(lockedBy as BasePadlock)) {
+		lockDef.baseLock = lockedBy as BasePadlock;
+		lockDef.minimumRole = basePadlockMinimumRole(lockDef.baseLock);
+	}
+
+	modStorage.deviousPadlock.itemGroups[group] = lockDef;
 	syncStorage();
 }
 
@@ -114,6 +129,41 @@ export async function inspectDeviousPadlock(): Promise<void> {
 	//@ts-ignore
 	await CommonSetScreen("Character", "InspectDeviousPadlock");
 	DialogLeave();
+}
+
+export function canUseBasePadlock(target1: Character, target2: Character, padlockOwner: number, baseLock: BasePadlock): boolean {
+	if (target1.MemberNumber !== padlockOwner) return false;
+
+	/*
+		NOTE:
+		We handle the special case of BlockLoverLockOwner on changePadlockConfigurations rather than here,
+		both due to easier LogQuery handling and to ensure that we don't accidentally restrict owners from
+		getting to the owner padlock (in the inspect subscreen) as a result of the intermediary lovers padlock
+		being disabled for them, preventing back/next navigation.
+
+		We also handle Block*LockSelf in changePadlockConfigurations as well, though solely for the aforementioned
+		ease of handling.
+	*/
+	if (baseLock === BasePadlock.EXCLUSIVE) return true;
+	if (baseLock === BasePadlock.LOVERS) return (
+		(target1.MemberNumber === target2.MemberNumber && target2.Lovership.length > 0) ||
+		target1.IsLoverOfCharacter(target2) || target2.IsOwnedByCharacter(target1)
+	)
+	if (baseLock === BasePadlock.OWNER) return (
+		(target1.MemberNumber === target2.MemberNumber && target2.Ownership != null) ||
+		target2.IsOwnedByCharacter(target1)
+	)
+	return false;
+}
+
+export function basePadlockMinimumRole(baseLock: BasePadlock, currentMinimumRole?: KeyHolderMinimumRole): KeyHolderMinimumRole {
+	if (baseLock === BasePadlock.LOVERS) {
+		if (currentMinimumRole === KeyHolderMinimumRole.OWNER) return currentMinimumRole;
+		return KeyHolderMinimumRole.LOVER;
+	}
+	if (baseLock === BasePadlock.OWNER) return KeyHolderMinimumRole.OWNER;
+	// Default (includes BasePadlock.EXCLUSIVE)
+	return currentMinimumRole ?? KeyHolderMinimumRole.EVERYONE_EXCEPT_WEARER;
 }
 
 export function canPutDeviousPadlock(groupName: AssetGroupItemName, target1: Character, target2: Character): boolean {
@@ -253,6 +303,27 @@ export async function changePadlockConfigurations(
 			}
 		}
 	}
+	if (typeof config?.baseLock === "string" && canUseBasePadlock(sender, Player, modStorage.deviousPadlock.itemGroups[groupName].owner, config.baseLock)) {
+		if (
+			modStorage.deviousPadlock.itemGroups[groupName].baseLock !== config.baseLock &&
+			!(config.baseLock === BasePadlock.LOVERS && Player.IsOwnedByCharacter(sender) && LogQuery("BlockLoverLockOwner", "LoverRule")) &&
+			!(Player.MemberNumber === sender.MemberNumber && (
+				(config.baseLock === BasePadlock.OWNER && LogQuery("BlockOwnerLockSelf", "OwnerRule")) ||
+				(config.baseLock === BasePadlock.LOVERS && LogQuery("BlockLoverLockSelf", "LoverRule"))
+			))
+		) {
+			const item = InventoryGet(Player, groupName);
+			if (item && item.Property.LockedBy !== config.baseLock) {
+				item.Property.LockedBy = config.baseLock;
+				item.Property.LockMemberNumber = modStorage.deviousPadlock.itemGroups[groupName].owner;
+				const successful = ValidationSanitizeLock(Player, item);
+				if (successful) {
+					modStorage.deviousPadlock.itemGroups[groupName].baseLock = config.baseLock;
+					ChatRoomCharacterUpdate(Player);
+				}
+			}
+		}
+	}
 	if (typeof config?.note === "string") {
 		modStorage.deviousPadlock.itemGroups[groupName].note = config.note;
 	}
@@ -275,11 +346,13 @@ function checkDeviousPadlocks(target: Character): void {
 		Object.keys(modStorage.deviousPadlock.itemGroups).forEach((groupName: AssetGroupItemName) => {
 			const currentItem = InventoryGet(Player, groupName);
 			const savedItem = modStorage.deviousPadlock.itemGroups[groupName].item;
+			const owner = modStorage.deviousPadlock.itemGroups[groupName].owner;
+			const basePadlock = modStorage.deviousPadlock.itemGroups[groupName].baseLock ?? BasePadlock.EXCLUSIVE;
 
 			const property = currentItem?.Property;
 			const padlockChanged = !(
 				property?.Name === deviousPadlock.Name
-				&& property?.LockedBy === "ExclusivePadlock"
+				&& property?.LockedBy === basePadlock
 			);
 
 			const ignoredProperties = [
@@ -330,7 +403,8 @@ function checkDeviousPadlocks(target: Character): void {
 						...getIgnoredProperties(currentItem?.Asset?.Name === savedItem.name ? currentItem.Property : newItem.Property)
 					};
 					if (newItem.Property.Name !== deviousPadlock.Name) newItem.Property.Name = deviousPadlock.Name;
-					if (newItem.Property.LockedBy !== "ExclusivePadlock") newItem.Property.LockedBy = "ExclusivePadlock";
+					if (newItem.Property.LockedBy !== basePadlock) newItem.Property.LockedBy = basePadlock;
+					if (newItem.Property.LockMemberNumber !== owner) newItem.Property.LockMemberNumber = owner;
 					ValidationSanitizeProperties(Player, newItem);
 					ValidationSanitizeLock(Player, newItem);
 					modStorage.deviousPadlock.itemGroups[groupName].item = getSavedItemData(newItem);
@@ -368,7 +442,7 @@ function checkDeviousPadlocks(target: Character): void {
 	Player.Appearance.forEach((item) => {
 		if (
 			item.Property?.Name === deviousPadlock.Name &&
-			item.Property?.LockedBy === "ExclusivePadlock"
+			Object.values(BasePadlock).includes(item.Property?.LockedBy as BasePadlock)
 		) {
 			if (
 				!modStorage.deviousPadlock.itemGroups ||
@@ -483,19 +557,21 @@ export function loadDeviousPadlock(): void {
 		}
 	});
 
-	hookFunction("InventoryItemMiscExclusivePadlockDraw", HookPriority.ADD_BEHAVIOR, (args, next) => {
-		const item = InventoryGet(CurrentCharacter, CurrentCharacter.FocusGroup.Name);
-		if (
-			item.Property?.Name === deviousPadlock.Name &&
-			(
-				CurrentCharacter.IsPlayer() || CurrentCharacter.DOGS
-			)
-		) {
-			inspectDeviousPadlock();
-			// DialogChangeMode("items");
-			return;
-		}
-		next(args);
+	Object.values(BasePadlock).forEach((baseLock) => {
+		hookFunction(`InventoryItemMisc${baseLock}Draw`, HookPriority.ADD_BEHAVIOR, (args, next) => {
+			const item = InventoryGet(CurrentCharacter, CurrentCharacter.FocusGroup.Name);
+			if (
+				item.Property?.Name === deviousPadlock.Name &&
+				(
+					CurrentCharacter.IsPlayer() || CurrentCharacter.DOGS
+				)
+			) {
+				inspectDeviousPadlock();
+				// DialogChangeMode("items");
+				return;
+			}
+			next(args);
+		});
 	});
 
 	hookFunction("DialogCanUnlock", HookPriority.ADD_BEHAVIOR, (args, next) => {
@@ -531,7 +607,7 @@ export function loadDeviousPadlock(): void {
 		const [C, Item, Lock, MemberNumber] = args as [Character, Item | AssetGroupName, Item | AssetLockType, null | number | string];
 		// @ts-ignore
 		if ([Lock.Asset?.Name, Lock].includes(deviousPadlock.Name)) {
-			args[2] = "ExclusivePadlock";
+			args[2] = Object.values(BasePadlock).includes((typeof Lock === "string" ? Lock : Lock.Asset?.Name) as BasePadlock) ? Lock : BasePadlock.EXCLUSIVE;
 			if (args[1].Property) {
 				args[1].Property.Name = deviousPadlock.Name;
 			} else {

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -3,7 +3,7 @@ import { getPlayer, MOD_DATA } from "zois-core";
 import { messagesManager } from "zois-core/messaging";
 import { hookFunction, HookPriority } from "zois-core/modsApi";
 import { RemoteConnectMinimumRole } from "./remoteControl";
-import { PutPadlockMinimumRole, KeyHolderMinimumRole } from "./deviousPadlock";
+import { PutPadlockMinimumRole, KeyHolderMinimumRole, BasePadlock } from "./deviousPadlock";
 import { cloneDeep } from "lodash-es";
 
 
@@ -26,6 +26,7 @@ export interface ModStorage {
         itemGroups?: Record<AssetGroupItemName, {
             item: SavedItem
             owner: number
+            baseLock?: BasePadlock
             minimumRole?: KeyHolderMinimumRole
             memberNumbers?: number[]
             note?: string


### PR DESCRIPTION
This PR is both a suggestion and implementation combined.

## Overview
Adds a new configuration option to DOGS padlocks: "Base Lock". This allows the owner of the padlock (the applicator) to select the underlying BC lock that DOGS uses from those that they are normally eligible to use (out of: exclusive, lovers, owner).

This has a number of benefits, including higher base security (without DOGS active), a greatly reduced number of DOGS triggers (referring to DOGS resetting unauthorized changes) from non-DOGS users (due to higher base security), an increased sense of identity for lovers/owners, and so on.

## Limitations
The higher base security is a double-edged sword, in the sense that due to validation catching any changes from 3rd parties that don't have access to the base lock (e.g. for lovers and owner padlocks), DOGS' keyholder features need to be restricted when these alternate base locks are used. Specifically:
- "Minimum Role" is forced to meet the minimum in BC (e.g. for a lovers lock, minimum role is >= Lovers; for an owner lock, minimum role is >= Owner).
- "Member Numbers"-based keyholders are not supported.

This limitation can be mitigated by proxying changes through DOGS via the wearer, similar to `padlockRemove` for combination locks, but for everything from removal to property updates. Of course, this is non-trivial and prone to issues, which is why I've opted *not* to implement it. It can also be argued that the base lock *should* influence the maximum permissiveness DOGS allows, and that this limitation is actually the "correct" approach.

## Implementation
- A new `baseLock` property is now passed with DOGS locks, defaulting to Exclusive when not specified.
- All appropriate functions within DOGS have been updated to add support for different base locks (i.e. properly detecting them and defaulting as needed)
- The `Locking` page of the configuration screen has been updated to include a selection between the different base lock types.
  - This selection is only usable by the owner of the DOGS lock (the applicator), as this is the member number we'll be using (and enforcing) on the lock. Users that would otherwise be authorized to edit but are not the owner cannot use this selection.
  - Users may only select base locks that they would normally have access to (e.g. lovers having access to lover locks, owner having access to owner locks, etc.).
  - When a non-Exclusive base lock is set, the `Minimum Role` and `Member Numbers` inputs on the `Key Holders` page are updated and disabled as appropriate to ensure that they match with the aforementioned [limitations](#Limitations).
- Informational text has been added to the configuration screen to explain the role of the Base Lock feature.

## Testing
While I've done relatively thorough testing of this PR, its inherent nature means that there's the notable potential for edge cases to arise. It would be ideal for this to be tested in a smaller, staggered release (or within a dev pool) to try to reduce the potential for later bugs. Additionally, this would allow for testing in a wider range of relationship pairings, as opposed to only those that I have dev accounts for (which is especially pertinent due to how tightly integrated this feature is with relationships in BC).