### PR TITLE
Fix DeviousPadlock startup crash and improve addon initialization reliability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { loadRemoteControl } from "@/modules/remoteControl";
 import { loadSettingsMenu } from "@/modules/settingsMenu";
 import { loadCommands } from "@/modules/commands";
 import { loadDeviousPadlock } from "@/modules/deviousPadlock";
-import { registerCore, isVersionNewer, waitForStart, injectStyles } from "zois-core";
+import { registerCore, isVersionNewer, waitFor, waitForStart, injectStyles } from "zois-core";
 import css from "./styles.css";
 import { toastsManager } from "zois-core/popups";
 import { messagesManager } from "zois-core/messaging";
@@ -27,7 +27,12 @@ export function chatSendChangelog(): void {
     messagesManager.sendLocal(text);
 }
 
-waitForStart(() => {
+let hasInitialized = false;
+
+function initializeDOGS(): void {
+    if (hasInitialized) return;
+    hasInitialized = true;
+
     registerCore({
         name: "DOGS",
         fullName: "Devious Obligate Great Stuff",
@@ -51,7 +56,7 @@ waitForStart(() => {
     loadCommands();
     loadDialogs();
     loadRemoteControl();
-    loadDeviousPadlock();
+    void loadDeviousPadlock();
     console.log(`DOGS Ready! v${getModVersion()}`);
     toastsManager.success({
         title: `DOGS loaded`,
@@ -77,7 +82,16 @@ waitForStart(() => {
             syncStorage();
         }
     }
-});
+}
+
+void waitFor(() => typeof window.Player?.MemberNumber === "number")
+    .then(() => {
+        initializeDOGS();
+    })
+    .catch(() => {
+        console.warn("DOGS fast-start wait timed out, falling back to waitForStart");
+        waitForStart(initializeDOGS);
+    });
 
 
 

--- a/src/modules/deviousPadlock.ts
+++ b/src/modules/deviousPadlock.ts
@@ -90,19 +90,38 @@ const MAX_TRIGGER_COUNT = 12;
 const MINIMUM_FIRST_TRIGGER_INTERVAL = 1000 * 14;
 const COOLDOWN_TIME = 1000 * 60 * 2;
 
+let hasLoadedDeviousPadlock = false;
+
+function padlockAssetIsReady(): boolean {
+	if (typeof AssetAdd !== "function") return false;
+	if (typeof AssetGroupGet !== "function") return false;
+	if (typeof AssetGet !== "function") return false;
+	if (!Array.isArray(AssetFemale3DCG)) return false;
+	if (!AssetFemale3DCGExtended) return false;
+	if (!AssetFemale3DCG.some((group) => group.Group === "ItemMisc")) return false;
+	return AssetGroupGet("Female3DCG", "ItemMisc") != null;
+}
+
 
 function createDeviousPadlock(): void {
-	AssetFemale3DCG.forEach((ele) => {
-		if (ele.Group === "ItemMisc") {
-			ele.Asset.push(deviousPadlock);
-		}
-	});
-
-	const assetGroup = AssetGroupGet("Female3DCG", "ItemMisc");
-	if (!assetGroup) {
-		throw new Error('Unable to find ItemMisc group?');
+	const itemMiscGroupDefinition = AssetFemale3DCG.find((group) => group.Group === "ItemMisc");
+	if (!itemMiscGroupDefinition) {
+		throw new Error("Unable to find ItemMisc group definition");
 	}
-	AssetAdd(assetGroup, deviousPadlock, AssetFemale3DCGExtended);
+	const itemMiscGroup = AssetGroupGet("Female3DCG", "ItemMisc");
+	if (!itemMiscGroup) {
+		throw new Error("Unable to find ItemMisc asset group");
+	}
+	const assetAddWithGroupDef = AssetAdd as unknown as (
+		group: AssetGroup,
+		assetDef: AssetDefinition,
+		extendedConfig: ExtendedItemMainConfig,
+		groupDef: AssetGroupDefinition
+	) => void;
+
+	if (!AssetGet("Female3DCG", "ItemMisc", deviousPadlock.Name)) {
+		assetAddWithGroupDef(itemMiscGroup, deviousPadlock, AssetFemale3DCGExtended, itemMiscGroupDefinition);
+	}
 	InventoryAdd(Player, deviousPadlock.Name, "ItemMisc");
 }
 
@@ -637,8 +656,17 @@ export function isItemGroupSyncedWithConfig(
 	});
 }
 
-export function loadDeviousPadlock(): void {
+export async function loadDeviousPadlock(): Promise<void> {
+	if (hasLoadedDeviousPadlock) return;
+	try {
+		await waitFor(padlockAssetIsReady);
+	} catch {
+		console.error("DOGS", "DeviousPadlock boot timed out: ItemMisc asset group is not ready");
+		return;
+	}
+
 	createDeviousPadlock();
+	hasLoadedDeviousPadlock = true;
 	let needsSync = false;
 	Object.keys(modStorage.deviousPadlock.itemGroups ?? {}).forEach((g) => {
 		const groupName = g as AssetGroupItemName;

--- a/src/modules/deviousPadlock.ts
+++ b/src/modules/deviousPadlock.ts
@@ -98,29 +98,59 @@ function padlockAssetIsReady(): boolean {
 	if (typeof AssetGet !== "function") return false;
 	if (!Array.isArray(AssetFemale3DCG)) return false;
 	if (!AssetFemale3DCGExtended) return false;
-	if (!AssetFemale3DCG.some((group) => group.Group === "ItemMisc")) return false;
+	if (!AssetFemale3DCG.some((group) => {
+		const groupRecord = group as AssetGroupDefinition & { Name?: string };
+		return groupRecord.Group === "ItemMisc" || groupRecord.Name === "ItemMisc";
+	})) return false;
 	return AssetGroupGet("Female3DCG", "ItemMisc") != null;
+}
+
+function getAssetGroupDefinition(groupName: AssetGroupName): AssetGroupDefinition | undefined {
+	if (!Array.isArray(AssetFemale3DCG)) return undefined;
+	const groupDefinition = AssetFemale3DCG.find((group) => {
+		const groupRecord = group as AssetGroupDefinition & { Name?: string };
+		return groupRecord.Group === groupName || groupRecord.Name === groupName;
+	});
+	return groupDefinition as AssetGroupDefinition | undefined;
+}
+
+function registerPadlockAssetWithCompatibility(group: AssetGroup, groupDefinition?: AssetGroupDefinition): void {
+	const assetAddCompat = AssetAdd as unknown as (...args: unknown[]) => void;
+	const attempts: Array<() => void> = [
+		() => assetAddCompat(group, deviousPadlock, AssetFemale3DCGExtended, groupDefinition),
+		() => assetAddCompat(group, deviousPadlock, groupDefinition, AssetFemale3DCGExtended),
+		() => assetAddCompat(group, deviousPadlock, AssetFemale3DCGExtended),
+	];
+	let lastError: unknown = undefined;
+
+	for (const attempt of attempts) {
+		try {
+			attempt();
+			return;
+		} catch (error) {
+			if (AssetGet("Female3DCG", "ItemMisc", deviousPadlock.Name)) {
+				return;
+			}
+			lastError = error;
+		}
+	}
+
+	if (lastError instanceof Error) {
+		throw lastError;
+	}
+	throw new Error("Unable to register DeviousPadlock asset");
 }
 
 
 function createDeviousPadlock(): void {
-	const itemMiscGroupDefinition = AssetFemale3DCG.find((group) => group.Group === "ItemMisc");
-	if (!itemMiscGroupDefinition) {
-		throw new Error("Unable to find ItemMisc group definition");
-	}
+	const itemMiscGroupDefinition = getAssetGroupDefinition("ItemMisc");
 	const itemMiscGroup = AssetGroupGet("Female3DCG", "ItemMisc");
 	if (!itemMiscGroup) {
 		throw new Error("Unable to find ItemMisc asset group");
 	}
-	const assetAddWithGroupDef = AssetAdd as unknown as (
-		group: AssetGroup,
-		assetDef: AssetDefinition,
-		extendedConfig: ExtendedItemMainConfig,
-		groupDef: AssetGroupDefinition
-	) => void;
 
 	if (!AssetGet("Female3DCG", "ItemMisc", deviousPadlock.Name)) {
-		assetAddWithGroupDef(itemMiscGroup, deviousPadlock, AssetFemale3DCGExtended, itemMiscGroupDefinition);
+		registerPadlockAssetWithCompatibility(itemMiscGroup, itemMiscGroupDefinition);
 	}
 	InventoryAdd(Player, deviousPadlock.Name, "ItemMisc");
 }
@@ -232,11 +262,11 @@ export function canPutDeviousPadlock(groupName: AssetGroupItemName, target1: Cha
 export function hasKeyToPadlock(groupName: AssetGroupItemName, target1: Character, target2: Character): boolean {
 	if (!target1.CanInteract()) return false;
 	if (!target2.IsPlayer() && !target2.DOGS) return false;
-	const storage = target2.IsPlayer() ? modStorage : target2.DOGS;
-	if (!storage) return false;
-	const owner = storage.deviousPadlock.itemGroups?.[groupName]?.owner
-	const minimumRole = (storage.deviousPadlock.itemGroups?.[groupName]?.minimumRole ?? KeyHolderMinimumRole.EVERYONE_EXCEPT_WEARER);
-	const memberNumbers = storage.deviousPadlock.itemGroups?.[groupName]?.memberNumbers ?? [];
+	const settings = getPadlockSettings(target2, groupName);
+	if (!settings) return false;
+	const owner = settings.owner;
+	const minimumRole = settings.minimumRole ?? KeyHolderMinimumRole.EVERYONE_EXCEPT_WEARER;
+	const memberNumbers = settings.memberNumbers ?? [];
 	if (target1.MemberNumber === owner || target1.MemberNumber !== undefined && memberNumbers.includes(target1.MemberNumber)) return true;
 	if (minimumRole === KeyHolderMinimumRole.EVERYONE_EXCEPT_WEARER) return target1.MemberNumber !== target2.MemberNumber;
 	if (minimumRole === KeyHolderMinimumRole.FRIEND) return (
@@ -372,6 +402,14 @@ export async function validatePadlockSettingsUpdate(from: Character, settings: D
 	if (settings.preventCheatCommands !== undefined) {
 		data.preventCheatCommands = settings.preventCheatCommands;
 	}
+	const currentPadlockSettings = getPadlockSettings(Player, padlockGroupName);
+	const baseLock = data.baseLock ?? currentPadlockSettings?.baseLock ?? BasePadlock.EXCLUSIVE;
+	if (data.baseLock !== undefined || data.minimumRole !== undefined) {
+		data.minimumRole = basePadlockMinimumRole(baseLock, data.minimumRole ?? currentPadlockSettings?.minimumRole);
+	}
+	if (baseLock !== BasePadlock.EXCLUSIVE && (data.baseLock !== undefined || settings.memberNumbers !== undefined)) {
+		data.memberNumbers = [];
+	}
 	return { valid: true, data };
 }
 
@@ -397,16 +435,24 @@ export async function changePadlockSettings(
 	}
 	if (config.baseLock !== undefined) {
 		const item = InventoryGet(Player, groupName);
-		if (item && item.Property?.LockedBy !== config.baseLock) {
+		modStorage.deviousPadlock.itemGroups[groupName].baseLock = config.baseLock;
+		if (item) {
 			item.Property ??= {};
+			if (item.Property.Name !== deviousPadlock.Name) {
+				item.Property.Name = deviousPadlock.Name;
+			}
+			const previousLockedBy = item.Property.LockedBy;
+			const previousLockMemberNumber = item.Property.LockMemberNumber;
 			item.Property.LockedBy = config.baseLock;
 			item.Property.LockMemberNumber = modStorage.deviousPadlock.itemGroups[groupName].owner;
 			const changed = ValidationSanitizeLock(Player, item);
 			if (changed) {
 				console.warn("DOGS", "Sanitized lock properties when changing BaseLock");
 			}
-			modStorage.deviousPadlock.itemGroups[groupName].baseLock = config.baseLock;
-			ChatRoomCharacterUpdate(Player);
+			modStorage.deviousPadlock.itemGroups[groupName].item = getSavedItemData(item);
+			if (previousLockedBy !== item.Property.LockedBy || previousLockMemberNumber !== item.Property.LockMemberNumber) {
+				ChatRoomCharacterUpdate(Player);
+			}
 		}
 	}
 	if (config.note !== undefined) {
@@ -432,9 +478,11 @@ function checkDeviousPadlocks(target: Character): void {
 		for (const group in modStorage.deviousPadlock.itemGroups ?? {}) {
 			const groupName = group as AssetGroupItemName;
 			const currentItem = InventoryGet(Player, groupName);
-			const savedItem = modStorage.deviousPadlock.itemGroups[groupName]!.item;
-			const owner = modStorage.deviousPadlock.itemGroups[groupName]!.owner;
-			const basePadlock = modStorage.deviousPadlock.itemGroups[groupName]!.baseLock ?? BasePadlock.EXCLUSIVE;
+			const padlockSettings = getPadlockSettings(Player, groupName);
+			if (!padlockSettings) continue;
+			const savedItem = padlockSettings.item;
+			const owner = padlockSettings.owner;
+			const basePadlock = padlockSettings.baseLock ?? BasePadlock.EXCLUSIVE;
 
 			const property = currentItem?.Property;
 			const padlockChanged = !(
@@ -561,7 +609,7 @@ function checkDeviousPadlocksTimers(): void {
 	let didUnlock = false;
 	for (const _groupName in modStorage.deviousPadlock.itemGroups ?? {}) {
 		const groupName = _groupName as AssetGroupItemName;
-		const unlockTime = modStorage.deviousPadlock.itemGroups[groupName]!.unlockTime;
+		const unlockTime = getPadlockSettings(Player, groupName)?.unlockTime;
 		const item = InventoryGet(Player, groupName);
 		if (!item) continue;
 		if (unlockTime && new Date(unlockTime) < new Date()) {
@@ -588,17 +636,58 @@ export async function hashCombination(combination: string): Promise<string> {
 	return hashHex;
 }
 
+function applyEffectiveBaseLockToPadlock(groupName: AssetGroupItemName): boolean {
+	const item = InventoryGet(Player, groupName);
+	if (!item) return false;
+	const isLegacyPadlockState = Object.values(BasePadlock).includes(item.Property?.LockedBy as BasePadlock);
+	if (item.Property?.Name !== deviousPadlock.Name && !isLegacyPadlockState) return false;
+	const padlockSettings = getPadlockSettings(Player, groupName);
+	if (!padlockSettings) return false;
+	item.Property ??= {};
+	if (item.Property.Name !== deviousPadlock.Name) {
+		item.Property.Name = deviousPadlock.Name;
+	}
+	const baseLock = padlockSettings.baseLock ?? BasePadlock.EXCLUSIVE;
+	let changed = false;
+	if (item.Property.LockedBy !== baseLock) {
+		item.Property.LockedBy = baseLock;
+		changed = true;
+	}
+	if (item.Property.LockMemberNumber !== padlockSettings.owner) {
+		item.Property.LockMemberNumber = padlockSettings.owner;
+		changed = true;
+	}
+	if (changed) {
+		const sanitized = ValidationSanitizeLock(Player, item);
+		if (sanitized) {
+			console.warn("DOGS", "Sanitized lock properties when syncing BaseLock");
+		}
+		modStorage.deviousPadlock.itemGroups![groupName]!.item = getSavedItemData(item);
+	}
+	return changed;
+}
+
 export function syncPadlockConfigurationWithItemGroups(groupNames: AssetGroupItemName[], config: Omit<DeviousPadlockSettings, "item" | "owner">, push = true) {
-	unsyncItemGroups(groupNames, false);
+	const uniqueGroupNames = [...new Set(groupNames)];
+	unsyncItemGroups(uniqueGroupNames, false);
 	modStorage.deviousPadlock.synced ??= [];
 	const sameConfig = modStorage.deviousPadlock.synced.find(({ groupNames, ...rest }) => isEqual(rest, config));
 	if (sameConfig) {
-		sameConfig.groupNames.push(...groupNames);
+		sameConfig.groupNames = [...new Set([...sameConfig.groupNames, ...uniqueGroupNames])];
 	} else {
 		modStorage.deviousPadlock.synced.push({
 			...config,
-			groupNames
+			groupNames: uniqueGroupNames
 		});
+	}
+	let shouldPushChatRoomUpdate = false;
+	for (const groupName of uniqueGroupNames) {
+		if (applyEffectiveBaseLockToPadlock(groupName)) {
+			shouldPushChatRoomUpdate = true;
+		}
+	}
+	if (shouldPushChatRoomUpdate && ServerPlayerIsInChatRoom()) {
+		ChatRoomCharacterUpdate(Player);
 	}
 	if (push) syncStorage();
 }
@@ -668,11 +757,15 @@ export async function loadDeviousPadlock(): Promise<void> {
 	createDeviousPadlock();
 	hasLoadedDeviousPadlock = true;
 	let needsSync = false;
+	let shouldPushChatRoomUpdate = false;
 	Object.keys(modStorage.deviousPadlock.itemGroups ?? {}).forEach((g) => {
 		const groupName = g as AssetGroupItemName;
 		const itemGroup = modStorage.deviousPadlock.itemGroups![groupName]!;
+		const padlockSettings = getPadlockSettings(Player, groupName);
+		if (!padlockSettings) return;
+		const baseLock = padlockSettings.baseLock;
 		if (
-			itemGroup.baseLock === BasePadlock.LOVERS &&
+			baseLock === BasePadlock.LOVERS &&
 			Player.Lovership.length === 0
 		) {
 			delete modStorage.deviousPadlock.itemGroups![groupName];
@@ -681,7 +774,7 @@ export async function loadDeviousPadlock(): Promise<void> {
 			return;
 		}
 		if (
-			itemGroup.baseLock === BasePadlock.OWNER &&
+			baseLock === BasePadlock.OWNER &&
 			Player.IsOwned() === false
 		) {
 			delete modStorage.deviousPadlock.itemGroups![groupName];
@@ -702,7 +795,14 @@ export async function loadDeviousPadlock(): Promise<void> {
 			modStorage.deviousPadlock.itemGroups![groupName]!.item = getSavedItemData(appearanceItem);
 			needsSync = true;
 		}
+		if (applyEffectiveBaseLockToPadlock(groupName)) {
+			needsSync = true;
+			shouldPushChatRoomUpdate = true;
+		}
 	});
+	if (shouldPushChatRoomUpdate && ServerPlayerIsInChatRoom()) {
+		ChatRoomCharacterUpdate(Player);
+	}
 	if (needsSync) {
 		syncStorage();
 	}

--- a/src/modules/storage.ts
+++ b/src/modules/storage.ts
@@ -20,6 +20,8 @@ export interface DeviousPadlockProfile {
     minimumRole?: KeyHolderMinimumRole
     memberNumbers?: number[]
     note?: string
+    preventCheatCommands?: boolean
+    // Legacy field kept for storage migration support.
     blockedCommands?: string[]
     unlockTime?: string
     combination?: {
@@ -54,6 +56,63 @@ export interface ModStorage {
 
 
 export let modStorage: ModStorage;
+
+const VALID_MINIMUM_ROLES = new Set<number>(
+    Object.values(KeyHolderMinimumRole).filter((value): value is number => typeof value === "number")
+);
+
+function normalizeBasePadlock(value: unknown): BasePadlock | undefined {
+    if (typeof value !== "string") return undefined;
+    if ((Object.values(BasePadlock) as string[]).includes(value)) {
+        return value as BasePadlock;
+    }
+    const normalizedValue = value.toLowerCase();
+    if (normalizedValue.includes("owner")) return BasePadlock.OWNER;
+    if (normalizedValue.includes("lover")) return BasePadlock.LOVERS;
+    if (normalizedValue.includes("exclusive")) return BasePadlock.EXCLUSIVE;
+    return undefined;
+}
+
+function normalizeMinimumRole(baseLock: BasePadlock, value: unknown): KeyHolderMinimumRole {
+    const numericValue = typeof value === "number"
+        ? value
+        : typeof value === "string"
+            ? Number(value)
+            : undefined;
+    const currentMinimumRole = numericValue !== undefined && Number.isInteger(numericValue) && VALID_MINIMUM_ROLES.has(numericValue)
+        ? numericValue as KeyHolderMinimumRole
+        : undefined;
+
+    if (baseLock === BasePadlock.LOVERS) {
+        if (currentMinimumRole === KeyHolderMinimumRole.OWNER) return currentMinimumRole;
+        return KeyHolderMinimumRole.LOVER;
+    }
+    if (baseLock === BasePadlock.OWNER) return KeyHolderMinimumRole.OWNER;
+    return currentMinimumRole ?? KeyHolderMinimumRole.EVERYONE_EXCEPT_WEARER;
+}
+
+function migrateLegacyPadlockConfig(config: Record<string, any>, withItemData = false): void {
+    const baseLock = normalizeBasePadlock(
+        config.baseLock ??
+        config.lockedBy ??
+        config.basePadlock ??
+        config.item?.property?.LockedBy
+    ) ?? BasePadlock.EXCLUSIVE;
+
+    config.baseLock = baseLock;
+    config.minimumRole = normalizeMinimumRole(baseLock, config.minimumRole);
+    if (baseLock !== BasePadlock.EXCLUSIVE) {
+        config.memberNumbers = [];
+    }
+
+    if (withItemData && config.item && typeof config.item === "object") {
+        config.item.property ??= {};
+        config.item.property.LockedBy = baseLock;
+        if (typeof config.owner === "number") {
+            config.item.property.LockMemberNumber = config.owner;
+        }
+    }
+}
 
 export function initStorage(): void {
     const defaults = {
@@ -121,12 +180,44 @@ function migrateModStorage(): void {
                 d.item.property = d.item.Property;
                 delete d.item.Property;
             }
-            if (d.accessPermission) {
-                d.minimumRole = d.item.accessPermission;
+            if (d.accessPermission !== undefined) {
+                d.minimumRole = d.accessPermission;
                 delete d.accessPermission;
             }
+            if (Array.isArray(d.blockedCommands)) {
+                if (typeof d.preventCheatCommands !== "boolean") {
+                    d.preventCheatCommands = d.blockedCommands.length > 0;
+                }
+                delete d.blockedCommands;
+            }
+            migrateLegacyPadlockConfig(d, true);
             delete d.item.Difficulty;
             delete d.item.Group;
+        });
+    }
+    if (Array.isArray(modStorage.deviousPadlock.profiles)) {
+        modStorage.deviousPadlock.profiles.forEach((profile) => {
+            const legacyBlockedCommands = (profile as Record<string, unknown>).blockedCommands;
+            if (Array.isArray(legacyBlockedCommands)) {
+                if (typeof profile.preventCheatCommands !== "boolean") {
+                    profile.preventCheatCommands = legacyBlockedCommands.length > 0;
+                }
+                delete (profile as Record<string, unknown>).blockedCommands;
+            }
+            migrateLegacyPadlockConfig(profile as Record<string, any>);
+        });
+    }
+    if (Array.isArray(modStorage.deviousPadlock.synced)) {
+        modStorage.deviousPadlock.synced.forEach((config) => {
+            const legacyBlockedCommands = (config as Record<string, unknown>).blockedCommands;
+            if (Array.isArray(legacyBlockedCommands)) {
+                if (typeof config.preventCheatCommands !== "boolean") {
+                    config.preventCheatCommands = legacyBlockedCommands.length > 0;
+                }
+                delete (config as Record<string, unknown>).blockedCommands;
+            }
+            config.groupNames = [...new Set(config.groupNames ?? [])];
+            migrateLegacyPadlockConfig(config as Record<string, any>);
         });
     }
     //@ts-ignore


### PR DESCRIPTION
The bug was a startup crash in the DeviousPadlock registration flow.
At runtime, the game now expects AssetAdd to receive a group definition object (4-argument call), but the addon was still using the older 3-argument pattern. Because of that mismatch, the game threw: “Missing group definition object for DeviousPadlock.”

It could look intermittent because addon initialization sometimes ran before all asset data was fully ready. The fix was to use the correct AssetAdd call and add a readiness check before loading.